### PR TITLE
Fixed closing of client and async handling of frames

### DIFF
--- a/aiostomp/protocol.py
+++ b/aiostomp/protocol.py
@@ -35,13 +35,10 @@ class StompProtocol(object):
         self._frames_ready = []
 
     def feed_data(self, data):
-        pending_data = data
+        pending_data = self._feed_data(data)
 
-        while True:
+        while pending_data:
             pending_data = self._feed_data(pending_data)
-
-            if pending_data is None:
-                return
 
     def _feed_data(self, data):
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,6 +54,19 @@ class TestStompReader(AsyncTestCase):
 
         connect_mock.assert_called_once()
 
+    @patch('aiostomp.aiostomp.StompReader.connect')
+    @unittest_run_loop
+    async def test_transport_is_closed_connection_close(self, connect_mock):
+        stomp = StompReader(None, self.loop)
+
+        transport = Mock()
+
+        stomp.connection_made(transport)
+
+        connect_mock.assert_called_once()
+
+        stomp.close()
+
     def test_connection_can_be_lost(self):
         frame_handler = Mock()
         heartbeater = Mock()


### PR DESCRIPTION
Hi,

Thanks for the library, worked out of the box for initial test. However found below issues which I tried to fix, hence submitting it back to the community

I found that the messages were being handled in a synchronous manner due to awaiting the handlers which in turn was in a while loop. For this I added tasks to the loop and this seem to work fine.

Also received message after closing the client in one of the use cases, then saw the transport wasn't closed in the protocol close method, fixing that it is working as expected