### PR TITLE
Fixed a edge case in passing message with content-length

### DIFF
--- a/aiostomp/protocol.py
+++ b/aiostomp/protocol.py
@@ -117,7 +117,7 @@ class StompProtocol(object):
 
             missing_length = content_length - existing_length
             # Wait till the entire body is received
-            if len(data) < missing_length:
+            if len(data) <= missing_length:
                 self._intermediate_frame['body'] += data
                 return None, None
 

--- a/tests/test_recv_frame.py
+++ b/tests/test_recv_frame.py
@@ -189,6 +189,31 @@ class TestRecvFrame(TestCase):
 
         self.assertEqual(self.protocol._pending_parts, [])
 
+    def test_read_content_by_length_EOF_multipacket(self):
+        stream_data = (
+            b'ERROR\n',
+            b'header:1.0\n',
+            b'content-length:3\n\n'
+            b'\x00\x00',
+            b'\x00',
+            b'\x00\n'
+        )
+
+        for data in stream_data:
+            self.protocol.feed_data(data)
+
+        frames = self.protocol.pop_frames()
+        self.assertEqual(len(frames), 2)
+
+        self.assertEqual(frames[0].command, u'ERROR')
+        self.assertEqual(frames[0].headers, {u'header': u'1.0',
+                                             u'content-length': u'3'})
+        self.assertEqual(frames[0].body, b'\x00\x00\x00')
+
+        self.assertEqual(frames[1].command, u'HEARTBEAT')
+
+        self.assertEqual(self.protocol._pending_parts, [])
+
     def test_multi_partial_packet2(self):
         stream_data = (
             b'CONNECTED\n'


### PR DESCRIPTION
Hi,

Hit an issue again, previous implementation to support binary data missed out a corner case of not receiving end of frame along with the body data causing exceptions. Added a case to reproduce and fixed it (<= instead of < fixed it) 