### PR TITLE
Multiple updates

### DIFF
--- a/aiostomp/__init__.py
+++ b/aiostomp/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding:utf-8 -*-
 __version__ = '1.6.0'
 
-try:
-    from .aiostomp import AioStomp  # noqa
-except ImportError:
-    pass
+from .aiostomp import AioStomp
+
+__all__ = ["AioStomp"]

--- a/aiostomp/aiostomp.py
+++ b/aiostomp/aiostomp.py
@@ -3,47 +3,46 @@ import functools
 import logging
 import uuid
 import os
+from typing import List, Dict, Optional, Any, Union, Deque, cast
+from ssl import SSLContext
 
 from collections import deque, OrderedDict
 
-from aiostomp.protocol import StompProtocol as sp
+from aiostomp.protocol import StompProtocol as sp, Frame
 from aiostomp.errors import StompError, StompDisconnectedError, ExceededRetryCount
 from aiostomp.subscription import Subscription
 from aiostomp.heartbeat import StompHeartbeater
 
 AIOSTOMP_ENABLE_STATS = bool(os.environ.get('AIOSTOMP_ENABLE_STATS', False))
 AIOSTOMP_STATS_INTERVAL = int(os.environ.get('AIOSTOMP_STATS_INTERVAL', 10))
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("aiostomp")
 
 
 class AioStompStats:
-
-    def __init__(self):
+    def __init__(self) -> None:
         self.connection_count = 0
         self.interval = AIOSTOMP_STATS_INTERVAL
-        self.connection_stats = []
+        self.connection_stats: List[Dict[str, int]] = []
 
-    def print_stats(self):
+    def print_stats(self) -> None:
         logger.info('==== AioStomp Stats ====')
         logger.info('Connections count: {}'.format(self.connection_count))
         logger.info(' con | sent_msg | rec_msg ')
         for index, stats in enumerate(self.connection_stats):
-            logger.info(' {:>3} | {:>8} | {:>7} '.format(
-                index + 1,
-                stats['sent_msg'],
-                stats['rec_msg']))
+            logger.info(
+                ' {:>3} | {:>8} | {:>7} '.format(
+                    index + 1, stats['sent_msg'], stats['rec_msg']
+                )
+            )
         logger.info('========================')
 
-    def new_connection(self):
-        self.connection_stats.insert(0, {
-            'sent_msg': 0,
-            'rec_msg': 0
-        })
+    def new_connection(self) -> None:
+        self.connection_stats.insert(0, {'sent_msg': 0, 'rec_msg': 0})
 
         if len(self.connection_stats) > 5:
             self.connection_stats.pop()
 
-    def increment(self, field):
+    def increment(self, field: str) -> None:
         if len(self.connection_stats) == 0:
             self.new_connection()
 
@@ -53,24 +52,26 @@ class AioStompStats:
 
         self.connection_stats[0][field] += 1
 
-    async def run(self):
+    async def run(self) -> None:
         while True:
             await asyncio.sleep(self.interval)
             self.print_stats()
 
 
 class AutoAckContextManager:
-    def __init__(self, protocol, ack_mode='auto', enabled=True):
+    def __init__(
+        self, protocol: 'StompReader', ack_mode: str = 'auto', enabled: bool = True
+    ) -> None:
         self.protocol = protocol
         self.enabled = enabled
         self.ack_mode = ack_mode
         self.result = None
-        self.frame = None
+        self.frame: Optional[Frame] = None
 
-    def __enter__(self):
+    def __enter__(self) -> "AutoAckContextManager":
         return self
 
-    def __exit__(self, exc_type, exc_value, exc_traceback):
+    def __exit__(self, exc_type: type, exc_value: Exception, exc_traceback: Any) -> None:
         if not self.enabled:
             return
 
@@ -85,18 +86,25 @@ class AutoAckContextManager:
 
 
 class AioStomp:
-
-    def __init__(self, host, port,
-                 ssl_context=None,
-                 client_id=None,
-                 reconnect_max_attempts=-1, reconnect_timeout=1000,
-                 heartbeat=True, heartbeat_interval_cx=1000, heartbeat_interval_cy=1000,
-                 error_handler=None, loop=None):
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        ssl_context: Optional[SSLContext] = None,
+        client_id: Optional[str] = None,
+        reconnect_max_attempts: int = -1,
+        reconnect_timeout: int = 1000,
+        heartbeat: bool = True,
+        heartbeat_interval_cx: int = 1000,
+        heartbeat_interval_cy: int = 1000,
+        error_handler=None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ):
 
         self._heartbeat = {
             'enabled': heartbeat,
             'cx': heartbeat_interval_cx,
-            'cy': heartbeat_interval_cy
+            'cy': heartbeat_interval_cy,
         }
 
         self._host = host
@@ -110,18 +118,24 @@ class AioStomp:
             self._stats_handler = self._loop.create_task(self._stats.run())
 
         self._protocol = StompProtocol(
-            self, host, port, heartbeat=self._heartbeat,
-            ssl_context=ssl_context, client_id=client_id,
-            stats=self._stats, loop=self._loop)
+            self,
+            host,
+            port,
+            heartbeat=self._heartbeat,
+            ssl_context=ssl_context,
+            client_id=client_id,
+            stats=self._stats,
+            loop=self._loop,
+        )
         self._last_subscribe_id = 0
-        self._subscriptions = {}
+        self._subscriptions: Dict[str, Subscription] = {}
 
         self._connected = False
         self._closed = False
-        self._username = None
-        self._password = None
+        self._username: Optional[str] = None
+        self._password: Optional[str] = None
 
-        self._retry_interval = .5
+        self._retry_interval = 0.5
         self._is_retrying = False
 
         self._reconnect_max_attempts = reconnect_max_attempts
@@ -130,22 +144,24 @@ class AioStomp:
 
         self._on_error = error_handler
 
-    async def connect(self, username=None, password=None):
+    async def connect(
+        self, username: Optional[str] = None, password: Optional[str] = None
+    ) -> None:
         logger.debug('connect')
         self._username = username
         self._password = password
 
         await self._reconnect()
 
-    def _resubscribe_queues(self):
+    def _resubscribe_queues(self) -> None:
         for subscription in self._subscriptions.values():
             self._protocol.subscribe(subscription)
 
-    def _increment_retry_interval(self):
+    def _increment_retry_interval(self) -> None:
         self._reconnect_attempts += 1
-        self._retry_interval = min(60, 1.5 * self._retry_interval)
+        self._retry_interval = min(60.0, 1.5 * self._retry_interval)
 
-    def _should_retry(self):
+    def _should_retry(self) -> bool:
         if self._reconnect_max_attempts == -1:
             return True
 
@@ -154,16 +170,15 @@ class AioStomp:
 
         return False
 
-    async def _reconnect(self):
+    async def _reconnect(self) -> None:
         self._is_retrying = True
         while True:
             try:
-                logger.info('Connecting to stomp server: {}:{}'.format(
-                    self._host, self._port))
+                logger.info('Connecting to stomp server: %s:%s', self._host, self._port)
 
                 await self._protocol.connect(
-                    username=self._username,
-                    password=self._password)
+                    username=self._username, password=self._password
+                )
 
                 self._retry_interval = 0.5
                 self._reconnect_attempts = 0
@@ -180,17 +195,19 @@ class AioStomp:
                 logger.info('Connecting to stomp server failed.')
 
                 if self._should_retry():
-                    logger.info('Retrying in {} seconds'.format(self._retry_interval))
+                    logger.info('Retrying in %s seconds', self._retry_interval)
                     await asyncio.sleep(self._retry_interval)
                 else:
                     logger.error('All connections attempts failed.')
                     if self._on_error:
-                        asyncio.ensure_future(self._on_error(ExceededRetryCount(self)), loop=self._loop)
+                        asyncio.ensure_future(
+                            self._on_error(ExceededRetryCount(self)), loop=self._loop
+                        )
                     break
 
                 self._increment_retry_interval()
 
-    def close(self):
+    def close(self) -> None:
         # Indicate requested closure to break the reconnect loop
         self._closed = True
 
@@ -200,7 +217,7 @@ class AioStomp:
         if AIOSTOMP_ENABLE_STATS:
             self._stats_handler.cancel()
 
-    def connection_lost(self, exc):
+    def connection_lost(self, exc: Optional[Exception]) -> None:
         self._connected = False
 
         # If close has been requested, do no reconnect!
@@ -211,8 +228,15 @@ class AioStomp:
             logger.info('Connection lost, will retry.')
             asyncio.ensure_future(self._reconnect(), loop=self._loop)
 
-    def subscribe(self, destination, ack='auto', extra_headers=None, handler=None, auto_ack=True):
-        extra_headers = {} if extra_headers is None else extra_headers
+    def subscribe(
+        self,
+        destination: str,
+        ack: str = 'auto',
+        extra_headers=None,
+        handler=None,
+        auto_ack=True,
+    ) -> Subscription:
+        extra_headers = extra_headers or {}
         self._last_subscribe_id += 1
 
         subscription = Subscription(
@@ -221,7 +245,8 @@ class AioStomp:
             ack=ack,
             extra_headers=extra_headers,
             handler=handler,
-            auto_ack=auto_ack)
+            auto_ack=auto_ack,
+        )
 
         self._subscriptions[str(self._last_subscribe_id)] = subscription
 
@@ -230,77 +255,87 @@ class AioStomp:
 
         return subscription
 
-    def unsubscribe(self, subscription):
+    def unsubscribe(self, subscription: Subscription) -> None:
         subscription_id = str(subscription.id)
 
         if subscription_id in self._subscriptions.keys():
             self._protocol.unsubscribe(subscription)
             del self._subscriptions[subscription_id]
 
-    def _encode(self, value):
+    def _encode(self, value: Union[str, bytes]) -> bytes:
         if isinstance(value, str):
             return value.encode('utf-8')
         return value
 
-    def send(self, destination, body='', headers=None, send_content_length=True):
-        headers = {} if headers is None else headers
+    def send(
+        self,
+        destination: str,
+        body: Union[str, bytes] = '',
+        headers: Optional[Dict[str, Any]] = None,
+        send_content_length=True,
+    ) -> None:
+        headers = headers or {}
         headers['destination'] = destination
 
-        if body:
-            body = self._encode(body)
+        body_b = self._encode(body)
 
-            # ActiveMQ determines the type of a message by the
-            # inclusion of the content-length header
-            if send_content_length:
-                headers['content-length'] = len(body)
+        # ActiveMQ determines the type of a message by the
+        # inclusion of the content-length header
+        if send_content_length:
+            headers['content-length'] = len(body_b)
 
-        return self._protocol.send(headers, body)
+        self._protocol.send(headers, body_b)
 
-    def _subscription_auto_ack(self, frame):
-        key = frame.headers.get('subscription')
+    def _subscription_auto_ack(self, frame: Frame) -> bool:
+        key = frame.headers.get('subscription', '')
 
         subscription = self._subscriptions.get(key)
         if not subscription:
-            logger.warn('Subscription %s not found.' % key)
+            logger.warning('Subscription %s not found', key)
             return True
 
         if subscription.auto_ack:
-            logger.warn('Auto ack/nack is enabled. Ignoring call.')
+            logger.warning('Auto ack/nack is enabled. Ignoring call.')
             return True
 
         return False
 
-    def ack(self, frame):
+    def ack(self, frame: Frame) -> None:
         if self._subscription_auto_ack(frame):
             return
 
-        return self._protocol.ack(frame)
+        self._protocol.ack(frame)
 
-    def nack(self, frame):
+    def nack(self, frame: Frame) -> None:
         if self._subscription_auto_ack(frame):
             return
 
-        return self._protocol.nack(frame)
+        self._protocol.nack(frame)
 
-    def get(self, key):
+    def get(self, key: str) -> Optional[Subscription]:
         return self._subscriptions.get(key)
 
 
 class StompReader(asyncio.Protocol):
+    def __init__(
+        self,
+        frame_handler: AioStomp,
+        loop: asyncio.AbstractEventLoop,
+        heartbeat: Optional[Dict[str, Any]] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        client_id: Optional[str] = None,
+        stats: Optional[AioStompStats] = None,
+    ):
 
-    def __init__(self, frame_handler,
-                 loop=None, heartbeat=None,
-                 username=None, password=None,
-                 client_id=None,
-                 stats=None):
+        self.handlers_map = {
+            'MESSAGE': self._handle_message,
+            'CONNECTED': self._handle_connect,
+            'ERROR': self._handle_error,
+        }
 
-        self.handlers_map = {'MESSAGE': self._handle_message,
-                             'CONNECTED': self._handle_connect,
-                             'ERROR': self._handle_error
-                             }
-
-        self.heartbeat = {} if heartbeat is None else heartbeat
-        self.heartbeater = None
+        self.heartbeat = heartbeat or {}
+        self.heartbeater: Optional[StompHeartbeater] = None
 
         self._loop = loop
         self._frame_handler = frame_handler
@@ -308,22 +343,22 @@ class StompReader(asyncio.Protocol):
         self._stats = stats
 
         self._waiter = None
-        self._frames = deque()
+        self._frames: Deque[bytes] = deque()
 
-        self._transport = None
+        self._transport: Optional[asyncio.Transport] = None
         self._protocol = sp()
-        self._connect_headers = OrderedDict()
+        self._connect_headers: OrderedDict[str, str] = OrderedDict()
 
         self._connect_headers['accept-version'] = '1.1'
 
         if client_id is not None:
             unique_id = uuid.uuid4()
-            self._connect_headers['client-id'] = '{}-{}'.format(client_id, unique_id)
+            self._connect_headers['client-id'] = f'{client_id}-{unique_id}'
 
         if self.heartbeat.get('enabled'):
             self._connect_headers['heart-beat'] = '{},{}'.format(
-                self.heartbeat.get('cx', 0),
-                self.heartbeat.get('cy', 0))
+                self.heartbeat.get('cx', 0), self.heartbeat.get('cy', 0)
+            )
 
         if username is not None:
             self._connect_headers['login'] = username
@@ -331,8 +366,7 @@ class StompReader(asyncio.Protocol):
         if password is not None:
             self._connect_headers['passcode'] = password
 
-    def close(self):
-
+    def close(self) -> None:
         # Close the transport only if already connection is made
         if self._transport:
             # Close the transport to stomp receiving any more data
@@ -342,12 +376,18 @@ class StompReader(asyncio.Protocol):
             self.heartbeater.shutdown()
             self.heartbeater = None
 
-    def connect(self):
-        buf = self._protocol.build_frame(
-            'CONNECT', headers=self._connect_headers)
+    def connect(self) -> None:
+        buf = self._protocol.build_frame('CONNECT', headers=self._connect_headers)
+        if not self._transport:
+            raise StompDisconnectedError()
         self._transport.write(buf)
 
-    def send_frame(self, command, headers=None, body=''):
+    def send_frame(
+        self,
+        command: str,
+        headers: Optional[Dict[str, Any]] = None,
+        body: Union[str, bytes] = b'',
+    ) -> None:
         headers = {} if headers is None else headers
         buf = self._protocol.build_frame(command, headers, body)
 
@@ -357,25 +397,25 @@ class StompReader(asyncio.Protocol):
         if self._stats:
             self._stats.increment('sent_msg')
 
-        return self._transport.write(buf)
+        self._transport.write(buf)
 
-    def ack(self, frame):
+    def ack(self, frame: Frame) -> None:
         headers = {
             'subscription': frame.headers['subscription'],
-            'message-id': frame.headers['message-id']
+            'message-id': frame.headers['message-id'],
         }
 
         return self.send_frame('ACK', headers)
 
-    def nack(self, frame):
+    def nack(self, frame: Frame) -> None:
         headers = {
             'subscription': frame.headers['subscription'],
-            'message-id': frame.headers['message-id']
+            'message-id': frame.headers['message-id'],
         }
 
-        return self.send_frame('NACK', headers)
+        self.send_frame('NACK', headers)
 
-    def connection_made(self, transport):
+    def connection_made(self, transport: asyncio.Transport) -> None:
         logger.info("Connected")
         super().connection_made(transport)
 
@@ -383,7 +423,7 @@ class StompReader(asyncio.Protocol):
 
         self.connect()
 
-    def connection_lost(self, exc):
+    def connection_lost(self, exc: Optional[Exception]) -> None:
         logger.debug("connection lost")
 
         super().connection_lost(exc)
@@ -396,49 +436,55 @@ class StompReader(asyncio.Protocol):
 
         self._frame_handler.connection_lost(exc)
 
-    async def _handle_connect(self, frame):
+    async def _handle_connect(self, frame: Frame) -> None:
+        if self._transport is None:
+            return
+
         heartbeat = frame.headers.get('heart-beat')
+        logger.debug("Expecting heartbeats: %s", heartbeat)
         if heartbeat and self.heartbeat.get('enabled'):
             sx, sy = (int(x) for x in heartbeat.split(','))
 
             if sy:
                 interval = max(self.heartbeat.get('cx', 0), sy)
-                self.heartbeater = StompHeartbeater(self._transport, interval, loop=self._loop)
+                logger.debug("Sending heartbeats every %sms", interval)
+                self.heartbeater = StompHeartbeater(
+                    self._transport, interval=interval, loop=self._loop
+                )
                 await self.heartbeater.start()
 
-    async def _handle_message(self, frame):
-        key = frame.headers.get('subscription')
+    async def _handle_message(self, frame: Frame) -> None:
+        key = frame.headers.get('subscription', '')
 
         subscription = self._frame_handler.get(key)
         if not subscription:
-            logger.warn('Subscription %s not found' % key)
+            logger.warning('Subscription %s not found', key)
             return
 
         if self._stats:
             self._stats.increment('rec_msg')
 
-        with AutoAckContextManager(self,
-                                   ack_mode=subscription.ack,
-                                   enabled=subscription.auto_ack) as ack_context:
+        with AutoAckContextManager(
+            self, ack_mode=subscription.ack, enabled=subscription.auto_ack
+        ) as ack_context:
             result = await subscription.handler(frame, frame.body)
 
             ack_context.frame = frame
             ack_context.result = result
 
-    async def _handle_error(self, frame):
+    async def _handle_error(self, frame: Frame) -> None:
         message = frame.headers.get('message')
 
         logger.error('Received error: %s' % message)
         logger.debug('Error details: %s' % frame.body)
 
         if self._frame_handler._on_error:
-            await self._frame_handler._on_error(
-                StompError(message, frame.body))
+            await self._frame_handler._on_error(StompError(message, frame.body))
 
-    async def _handle_exception(self, frame):
-        logger.warn('Unhandled frame: %s' % frame.command)
+    async def _handle_exception(self, frame: Frame) -> None:
+        logger.warning('Unhandled frame: %s', frame.command)
 
-    def data_received(self, data):
+    def data_received(self, data: Optional[bytes]) -> None:
         if not data:
             return
 
@@ -446,18 +492,26 @@ class StompReader(asyncio.Protocol):
 
         for frame in self._protocol.pop_frames():
             if frame.command != 'HEARTBEAT':
-                self._loop.create_task(self.handlers_map.get(frame.command,
-                                       self._handle_exception)(frame))
+                self._loop.create_task(
+                    self.handlers_map.get(frame.command, self._handle_exception)(frame)
+                )
 
-    def eof_received(self):
+    def eof_received(self) -> None:
         self.connection_lost(Exception('Got EOF from server'))
 
 
-class StompProtocol(object):
-
-    def __init__(self, handler, host, port,
-                 loop=None, heartbeat={}, ssl_context=None, client_id=None,
-                 stats=None):
+class StompProtocol:
+    def __init__(
+        self,
+        handler: AioStomp,
+        host: str,
+        port: int,
+        loop: asyncio.AbstractEventLoop,
+        heartbeat: Optional[Dict[str, Any]] = None,
+        ssl_context: Optional[SSLContext] = None,
+        client_id: Optional[str] = None,
+        stats: Optional[AioStompStats] = None,
+    ):
 
         self.host = host
         self.port = port
@@ -469,10 +523,13 @@ class StompProtocol(object):
             loop = asyncio.get_event_loop()
 
         self._loop = loop
-        self._heartbeat = heartbeat
+        self._heartbeat = heartbeat or {}
         self._handler = handler
+        self._protocol: Optional[StompReader] = None
 
-    async def connect(self, username=None, password=None):
+    async def connect(
+        self, username: Optional[str] = None, password: Optional[str] = None
+    ) -> None:
         self._factory = functools.partial(
             StompReader,
             self._handler,
@@ -481,40 +538,47 @@ class StompProtocol(object):
             client_id=self.client_id,
             loop=self._loop,
             heartbeat=self._heartbeat,
-            stats=self._stats)
+            stats=self._stats,
+        )
 
         trans, proto = await self._loop.create_connection(
-            self._factory, host=self.host, port=self.port,
-            ssl=self.ssl_context)
+            self._factory, host=self.host, port=self.port, ssl=self.ssl_context
+        )
 
         self._transport = trans
-        self._protocol = proto
+        self._protocol = cast(StompReader, proto)
 
-    def close(self):
-        self._protocol.close()
+    def close(self) -> None:
+        if self._protocol:
+            self._protocol.close()
 
-    def subscribe(self, subscription):
+    def subscribe(self, subscription: Subscription) -> None:
+        if self._protocol is None:
+            raise RuntimeError("Not connected")
+
         headers = {
             'id': subscription.id,
             'destination': subscription.destination,
-            'ack': subscription.ack
+            'ack': subscription.ack,
         }
         headers.update(subscription.extra_headers)
 
-        return self._protocol.send_frame('SUBSCRIBE', headers)
+        self._protocol.send_frame('SUBSCRIBE', headers)
 
-    def unsubscribe(self, subscription):
-        headers = {
-            'id': subscription.id,
-            'destination': subscription.destination
-        }
-        return self._protocol.send_frame('UNSUBSCRIBE', headers)
+    def unsubscribe(self, subscription: Subscription) -> None:
+        if self._protocol:
+            headers = {'id': subscription.id, 'destination': subscription.destination}
+            self._protocol.send_frame('UNSUBSCRIBE', headers)
 
-    def send(self, headers, body):
-        return self._protocol.send_frame('SEND', headers, body)
+    def send(self, headers: Dict[str, Any], body: Union[bytes, str]) -> None:
+        if self._protocol is None:
+            raise RuntimeError("Not connected")
+        self._protocol.send_frame('SEND', headers, body)
 
-    def ack(self, frame):
-        return self._protocol.ack(frame)
+    def ack(self, frame: Frame) -> None:
+        if self._protocol:
+            self._protocol.ack(frame)
 
-    def nack(self, frame):
-        return self._protocol.nack(frame)
+    def nack(self, frame: Frame) -> None:
+        if self._protocol:
+            self._protocol.nack(frame)

--- a/aiostomp/errors.py
+++ b/aiostomp/errors.py
@@ -1,8 +1,9 @@
+from typing import Any, Optional
+
 
 class StompError(Exception):
-
-    def __init__(self, message, detail):
-        super(StompError, self).__init__(message)
+    def __init__(self, message: Optional[str], detail: Any):
+        super().__init__(message)
         self.detail = detail
 
 
@@ -11,7 +12,6 @@ class StompDisconnectedError(Exception):
 
 
 class ExceededRetryCount(Exception):
-
-    def __init__(self, ref):
+    def __init__(self, ref: Any):
         super().__init__('Retry count exceeded!')
         self.ref = ref

--- a/aiostomp/frame.py
+++ b/aiostomp/frame.py
@@ -1,12 +1,18 @@
-class Frame(object):
+from typing import Dict, Union
 
-    def __init__(self, command, headers, body):
+
+class Frame:
+    def __init__(
+        self, command: str, headers: Dict[str, str], body: Union[str, bytes, None]
+    ):
         self.command = command
+        if '\n' in self.command:
+            raise RuntimeError(f"Invalid command {self.command}")
         self.headers = headers
         self.body = body
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         headers = ''
         if self.headers:
-            headers = ';'.join(["%s: %s" % (key, value) for key, value in self.headers.items()])
-        return '<Frame: %s headers: %s>' % (self.command, headers)
+            headers = ';'.join(f"{key}: {value}" for key, value in self.headers.items())
+        return f'<Frame: {self.command} headers: {headers}>'

--- a/aiostomp/heartbeat.py
+++ b/aiostomp/heartbeat.py
@@ -1,48 +1,51 @@
 import asyncio
-import logging
+from typing import Optional
 
 from contextlib import suppress
-
-logger = logging.getLogger()
 
 
 class StompHeartbeater:
 
     HEART_BEAT = b'\n'
 
-    def __init__(self, transport, interval=1000, loop=None):
+    def __init__(
+        self,
+        transport: asyncio.Transport,
+        loop: asyncio.AbstractEventLoop,
+        interval: int = 1000,
+    ):
         self._transport = transport
         self.interval = interval / 1000.0
         self.loop = loop
-        self.task = None
+        self.task: Optional[asyncio.Future[None]] = None
         self.is_started = False
 
         self.received_heartbeat = None
 
-    async def start(self):
+    async def start(self) -> None:
         if self.is_started:
             await self.stop()
 
         self.is_started = True
         self.task = asyncio.ensure_future(self.run(), loop=self.loop)
 
-    async def stop(self):
-        if self.is_started:
+    async def stop(self) -> None:
+        if self.is_started and self.task:
             self.is_started = False
             # Stop task and await it stopped:
             self.task.cancel()
             with suppress(asyncio.CancelledError):
                 await self.task
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         if self.task:
             self.task.cancel()
             self.task = None
 
-    async def run(self):
+    async def run(self) -> None:
         while True:
             await self.send()
             await asyncio.sleep(self.interval, loop=self.loop)
 
-    async def send(self):
+    async def send(self) -> None:
         self._transport.write(self.HEART_BEAT)

--- a/aiostomp/protocol.py
+++ b/aiostomp/protocol.py
@@ -2,8 +2,11 @@
 import logging
 import itertools
 from collections import deque
+from typing import List, Dict, Union, Any, Optional, Deque
 
 from aiostomp.frame import Frame
+
+logger = logging.getLogger("aiostomp.protocol")
 
 
 class Stomp:
@@ -12,7 +15,7 @@ class Stomp:
     V1_2 = '1.2'
 
 
-class StompProtocol(object):
+class StompProtocol:
 
     HEART_BEAT = b'\n'
     EOF = b'\x00'
@@ -21,41 +24,43 @@ class StompProtocol(object):
     MAX_DATA_LENGTH = 1024 * 1024 * 100
     MAX_COMMAND_LENGTH = 1024
 
-    def __init__(self, log_name='StompProtocol'):
-        self._pending_parts = []
-        self._frames_ready = []
-        self.logger = logging.getLogger(log_name)
+    def __init__(self) -> None:
+        self._pending_parts: List[bytes] = []
+        self._frames_ready: List[Frame] = []
 
         self.processed_headers = False
         self.awaiting_command = True
         self.read_length = 0
         self.content_length = -1
-        self.previous_byte = -1
+        self.previous_byte: Optional[bytes] = None
 
-        self.action = None
-        self.headers = {}
-        self.current_command = deque()
+        self.action: Optional[str] = None
+        self.headers: Dict[str, str] = {}
+        self.current_command: Deque[int] = deque()
 
         self._version = Stomp.V1_1
 
-    def _decode(self, byte_data):
+    def _decode(self, byte_data: Union[str, bytes, bytearray]) -> str:
         try:
             if isinstance(byte_data, (bytes, bytearray)):
                 return byte_data.decode('utf-8')
+            if isinstance(byte_data, str):
+                return byte_data
+            else:
+                raise TypeError("Must be bytes or string")
 
-            return byte_data
         except UnicodeDecodeError:
-            logging.error(u"string was: {}".format(byte_data))
+            logging.error("string was: %s", byte_data)
             raise
 
-    def _decode_header(self, header):
+    def _decode_header(self, header: bytes) -> str:
         decoded = []
 
-        stream = deque(header)
+        stream: Deque[int] = deque(header)
         has_data = True
 
         while has_data:
-            if len(stream) == 0:
+            if not stream:
                 has_data = False
                 break
 
@@ -74,21 +79,21 @@ class StompProtocol(object):
                     elif _next == b'r':
                         decoded.append(b'\r')
                     else:
-                        stream.appendleft(_next)
+                        stream.appendleft(_next[0])
                         decoded.append(_b)
             else:
                 decoded.append(_b)
 
         return self._decode(b''.join(decoded))
 
-    def _encode(self, value):
+    def _encode(self, value: Union[str, bytes]) -> bytes:
         if isinstance(value, str):
             return value.encode('utf-8')
 
         return value
 
-    def _encode_header(self, value):
-        value = '{}'.format(value)
+    def _encode_header(self, header_value: Any) -> str:
+        value = '{}'.format(header_value)
         if self._version == Stomp.V1_0:
             return value
 
@@ -107,47 +112,46 @@ class StompProtocol(object):
 
         return ''.join(encoded)
 
-    def reset(self):
-        self._pending_parts = []
+    def reset(self) -> None:
         self._frames_ready = []
 
-    def ends_with_crlf(self, data):
-        size = len(data)
-        ending = list(itertools.islice(data, size - 4, size))
-
-        return ending == self.CRLFCRLR
-
-    def feed_data(self, data):
-        read_size = len(data)
-        data = deque(data)
+    def feed_data(self, inp: bytes) -> None:
+        read_size = len(inp)
+        data: Deque[int] = deque(inp)
         i = 0
 
         while i < read_size:
             i += 1
             b = bytes([data.popleft()])
 
-            if (not self.processed_headers and
-               self.previous_byte == self.EOF and
-               b == self.EOF):
+            if (
+                not self.processed_headers
+                and self.previous_byte == self.EOF
+                and b == self.EOF
+            ):
                 continue
 
             if not self.processed_headers:
                 if self.awaiting_command and b == b'\n':
-                    self._frames_ready.append(Frame('HEARTBEAT', headers={}, body=''))
+                    self._frames_ready.append(Frame('HEARTBEAT', headers={}, body=None))
                     continue
                 else:
                     self.awaiting_command = False
 
-                self.current_command.append(b)
-                if b == b'\n' and (self.previous_byte == b'\n' or
-                                   self.ends_with_crlf(self.current_command)):
+                self.current_command.append(b[0])
+                if b == b'\n' and (
+                    self.previous_byte == b'\n' or ends_with_crlf(self.current_command)
+                ):
 
                     try:
                         self.action = self._parse_action(self.current_command)
                         self.headers = self._parse_headers(self.current_command)
+                        logger.debug("Parsed action %s", self.action)
 
-                        if (self.action in ('SEND', 'MESSAGE', 'ERROR') and
-                           'content-length' in self.headers):
+                        if (
+                            self.action in ('SEND', 'MESSAGE', 'ERROR')
+                            and 'content-length' in self.headers
+                        ):
                             self.content_length = int(self.headers['content-length'])
                         else:
                             self.content_length = -1
@@ -162,7 +166,7 @@ class StompProtocol(object):
                     if b == self.EOF:
                         self.process_command()
                     else:
-                        self.current_command.append(b)
+                        self.current_command.append(b[0])
 
                         if len(self.current_command) > self.MAX_DATA_LENGTH:
                             # error
@@ -173,15 +177,15 @@ class StompProtocol(object):
                         self.read_length = 0
                     else:
                         self.read_length += 1
-                        self.current_command.append(b)
+                        self.current_command.append(b[0])
 
             self.previous_byte = b
 
-    def process_command(self):
-        body = b''.join(self.current_command)
+    def process_command(self) -> None:
+        body: Optional[bytes] = bytes(self.current_command)
         if body == b'':
             body = None
-        frame = Frame(self.action, self.headers, body)
+        frame = Frame(self.action or "", self.headers, body)
         self._frames_ready.append(frame)
 
         self.processed_headers = False
@@ -189,23 +193,25 @@ class StompProtocol(object):
         self.content_length = -1
         self.current_command.clear()
 
-    def _read_line(self, input):
+    def _read_line(self, input: Deque[int]) -> bytes:
         result = []
         line_end = False
         while not line_end:
+            if not input:
+                break
             b = input.popleft()
-            if b == b'\n':
+            if b == b'\n'[0]:
                 line_end = True
                 break
             result.append(b)
 
-        return b''.join(result)
+        return bytes(result)
 
-    def _parse_action(self, data):
+    def _parse_action(self, data: Deque[int]) -> str:
         action = self._read_line(data)
         return self._decode(action)
 
-    def _parse_headers(self, data):
+    def _parse_headers(self, data: Deque[int]) -> Dict[str, str]:
         headers = {}
         while True:
             line = self._read_line(data)
@@ -216,20 +222,30 @@ class StompProtocol(object):
                 break
         return headers
 
-    def build_frame(self, command, headers={}, body=''):
-        lines = [command, '\n']
+    def build_frame(
+        self, command: str, headers: Optional[Dict[str, Any]] = None, body: Union[bytes, str] = ""
+    ) -> bytes:
+        lines: List[Union[str, bytes]] = [command, '\n']
 
-        for key, value in sorted(headers.items()):
-            lines.append('%s:%s\n' % (key, self._encode_header(value)))
+        if headers:
+            for key, value in sorted(headers.items()):
+                lines.append(f'{key}:{self._encode_header(value)}\n')
 
         lines.append('\n')
         lines.append(body)
         lines.append(self.EOF)
 
-        return b''.join([self._encode(line) for line in lines])
+        return b''.join(self._encode(line) for line in lines)
 
-    def pop_frames(self):
+    def pop_frames(self) -> List[Frame]:
         frames = self._frames_ready
         self._frames_ready = []
 
         return frames
+
+
+def ends_with_crlf(data: Deque[int]) -> bool:
+    size = len(data)
+    ending = list(itertools.islice(data, size - 4, size))
+
+    return ending == StompProtocol.CRLFCRLR

--- a/aiostomp/subscription.py
+++ b/aiostomp/subscription.py
@@ -1,9 +1,19 @@
-class Subscription(object):
+from typing import Dict, Any
 
-    def __init__(self, destination, id, ack, extra_headers, handler, auto_ack=True):
+
+class Subscription:
+    def __init__(
+        self,
+        destination: str,
+        id: int,
+        ack: str,
+        extra_headers: Dict[str, str],
+        handler: Any,
+        auto_ack: bool = True,
+    ):
         self.destination = destination
         self.id = id
         self.ack = ack
         self.extra_headers = extra_headers
         self.handler = handler
-        self.auto_ack = auto_ack
+        self.auto_ack: bool = auto_ack

--- a/aiostomp/test_utils.py
+++ b/aiostomp/test_utils.py
@@ -7,7 +7,6 @@ from unittest import TestCase
 
 
 class AsyncTestCase(TestCase):
-
     def setUp(self):
         self.loop = setup_test_loop()
         self.loop.run_until_complete(self.setUpAsync())
@@ -64,7 +63,6 @@ def unittest_run_loop(func, *args, **kwargs):
 
     @functools.wraps(func, *args, **kwargs)
     def new_func(self, *inner_args, **inner_kwargs):
-        return self.loop.run_until_complete(
-            func(self, *inner_args, **inner_kwargs))
+        return self.loop.run_until_complete(func(self, *inner_args, **inner_kwargs))
 
     return new_func

--- a/example/aiostomp
+++ b/example/aiostomp
@@ -1,1 +1,0 @@
-../aiostomp

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -7,10 +7,11 @@ from aiostomp.heartbeat import StompHeartbeater
 
 
 class TestStompHeartbeater(AsyncTestCase):
-
     async def setUpAsync(self):
         self.transport = Mock()
-        self.heartbeater = StompHeartbeater(self.transport, 100)
+        self.heartbeater = StompHeartbeater(
+            self.transport, loop=asyncio.get_event_loop(), interval=100
+        )
 
     @patch('aiostomp.heartbeat.StompHeartbeater.stop')
     @unittest_run_loop

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,7 +13,6 @@ from asynctest import CoroutineMock, Mock, patch
 
 
 class TestStompStats(AsyncTestCase):
-
     def test_can_increment_a_field(self):
         stats = AioStompStats()
         stats.increment('sent_msg')
@@ -37,7 +36,6 @@ class TestStompStats(AsyncTestCase):
 
 
 class TestStompReader(AsyncTestCase):
-
     @unittest_run_loop
     async def test_accept_version_header(self):
         stomp = StompReader(None, self.loop)
@@ -138,22 +136,20 @@ class TestStompReader(AsyncTestCase):
         stomp.send_frame('SUBSCRIBE', {'ack': 'auto'}, 'ç')
 
         stomp._transport.write.assert_called_with(
-            b'SUBSCRIBE\n'
-            b'ack:auto\n'
-            b'\n'
-            b'\xc3\xa7\x00')
+            b'SUBSCRIBE\n' b'ack:auto\n' b'\n' b'\xc3\xa7\x00'
+        )
 
     @unittest_run_loop
     async def test_can_connect(self):
         stomp = StompReader(
-            None,
-            self.loop,
-            heartbeat={'enabled': True, 'cx': 1000, 'cy': 1000})
+            None, self.loop, heartbeat={'enabled': True, 'cx': 1000, 'cy': 1000}
+        )
         stomp._transport = Mock()
 
         stomp.connect()
         stomp._transport.write.assert_called_with(
-            b'CONNECT\naccept-version:1.1\nheart-beat:1000,1000\n\n\x00')
+            b'CONNECT\naccept-version:1.1\nheart-beat:1000,1000\n\n\x00'
+        )
 
     @unittest_run_loop
     async def test_can_connect_with_username(self):
@@ -161,12 +157,14 @@ class TestStompReader(AsyncTestCase):
             None,
             self.loop,
             heartbeat={'enabled': True, 'cx': 1000, 'cy': 1000},
-            username='pkiefer')
+            username='pkiefer',
+        )
         stomp._transport = Mock()
 
         stomp.connect()
         stomp._transport.write.assert_called_with(
-            b'CONNECT\naccept-version:1.1\nheart-beat:1000,1000\nlogin:pkiefer\n\n\x00')  # noqa
+            b'CONNECT\naccept-version:1.1\nheart-beat:1000,1000\nlogin:pkiefer\n\n\x00'
+        )  # noqa
 
     @unittest_run_loop
     async def test_can_connect_with_password(self):
@@ -174,12 +172,14 @@ class TestStompReader(AsyncTestCase):
             None,
             self.loop,
             heartbeat={'enabled': True, 'cx': 1000, 'cy': 1000},
-            password='pass')
+            password='pass',
+        )
         stomp._transport = Mock()
 
         stomp.connect()
         stomp._transport.write.assert_called_with(
-            b'CONNECT\naccept-version:1.1\nheart-beat:1000,1000\npasscode:pass\n\n\x00')  # noqa
+            b'CONNECT\naccept-version:1.1\nheart-beat:1000,1000\npasscode:pass\n\n\x00'
+        )  # noqa
 
     @unittest_run_loop
     async def test_can_connect_with_login_pass(self):
@@ -188,29 +188,30 @@ class TestStompReader(AsyncTestCase):
             self.loop,
             heartbeat={'enabled': True, 'cx': 1000, 'cy': 1000},
             username='pkiefer',
-            password='pass')
+            password='pass',
+        )
         stomp._transport = Mock()
 
         stomp.connect()
         stomp._transport.write.assert_called_with(
-            b'CONNECT\naccept-version:1.1\nheart-beat:1000,1000\nlogin:pkiefer\npasscode:pass\n\n\x00')  # noqa
+            b'CONNECT\naccept-version:1.1\nheart-beat:1000,1000\nlogin:pkiefer\npasscode:pass\n\n\x00'
+        )  # noqa
 
     @patch('aiostomp.aiostomp.StompReader._handle_connect')
     @unittest_run_loop
     async def test_can_process_connected_frame(self, connect_handle_mock):
         stomp = StompReader(None, self.loop)
 
-        stomp.data_received(
-            b'CONNECTED\n'
-            b'heart-beat:1000,1000\n\n'
-            b'{}\x00')
+        stomp.data_received(b'CONNECTED\n' b'heart-beat:1000,1000\n\n' b'{}\x00')
 
         await asyncio.sleep(0.001)
         connect_handle_mock.assert_called_once()
 
     @patch('aiostomp.aiostomp.StompHeartbeater')
     @unittest_run_loop
-    async def test_can_handle_connected_frame_without_heartbeat(self, heartbeater_klass_mock):
+    async def test_can_handle_connected_frame_without_heartbeat(
+        self, heartbeater_klass_mock
+    ):
         frame = Frame('CONNECTED', {}, '{}')
 
         stomp = StompReader(None, self.loop)
@@ -220,38 +221,38 @@ class TestStompReader(AsyncTestCase):
 
     @patch('aiostomp.aiostomp.StompHeartbeater')
     @unittest_run_loop
-    async def test_can_handle_connected_frame_with_heartbeat(self, heartbeater_klass_mock):
-        frame = Frame('CONNECTED', {
-            'heart-beat': '1000,1000',
-        }, '{}')
+    async def test_can_handle_connected_frame_with_heartbeat(
+        self, heartbeater_klass_mock
+    ):
+        frame = Frame('CONNECTED', {'heart-beat': '1000,1000'}, '{}')
 
         heartbeater_mock = heartbeater_klass_mock.return_value
         heartbeater_mock.start = CoroutineMock()
 
         stomp = StompReader(
-            None,
-            self.loop,
-            heartbeat={'enabled': True, 'cx': 1000, 'cy': 1000})
+            None, self.loop, heartbeat={'enabled': True, 'cx': 1000, 'cy': 1000}
+        )
         stomp._transport = Mock()
         await stomp._handle_connect(frame)
 
-        heartbeater_klass_mock.assert_called_with(stomp._transport, 1000, loop=self.loop)
+        heartbeater_klass_mock.assert_called_with(
+            stomp._transport, interval=1000, loop=self.loop
+        )
         heartbeater_mock.start.assert_called_once()
 
     @patch('aiostomp.aiostomp.StompHeartbeater')
     @unittest_run_loop
-    async def test_can_handle_connected_frame_with_heartbeat_disabled(self, heartbeater_klass_mock):
-        frame = Frame('CONNECTED', {
-            'heart-beat': '1000,1000',
-        }, '{}')
+    async def test_can_handle_connected_frame_with_heartbeat_disabled(
+        self, heartbeater_klass_mock
+    ):
+        frame = Frame('CONNECTED', {'heart-beat': '1000,1000'}, '{}')
 
         heartbeater_mock = heartbeater_klass_mock.return_value
         heartbeater_mock.start = CoroutineMock()
 
         stomp = StompReader(
-            None,
-            self.loop,
-            heartbeat={'enabled': False, 'cx': 0, 'cy': 0})
+            None, self.loop, heartbeat={'enabled': False, 'cx': 0, 'cy': 0}
+        )
         stomp._transport = Mock()
         await stomp._handle_connect(frame)
 
@@ -270,7 +271,8 @@ class TestStompReader(AsyncTestCase):
             b'message-id:007\n'
             b'destination:/topic/test\n'
             b'\n'
-            b'blahh-line-a\n\nblahh-line-b\n\nblahh-line-c\x00')
+            b'blahh-line-a\n\nblahh-line-b\n\nblahh-line-c\x00'
+        )
 
         await asyncio.sleep(0.001)
         message_handle_mock.assert_called_once()
@@ -282,43 +284,45 @@ class TestStompReader(AsyncTestCase):
 
         await asyncio.sleep(0.001)
 
-        data = b'MESSAGE\n' \
-            b'content-length:14\nexpires:0\ndestination:/topic/' \
-            b'xxxxxxxxxxxxxxxxxxxxxxxxxl' \
-            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id' \
-            b':ID\\cxxxxxx-35207-1543430467768-204' \
-            b'\\c363\\c-1\\c1\\c463859\npersistent:true\ntimestamp' \
-            b':1548945234003\n\n222.222.22.222' \
-            b'\x00\nMESSAGE\ncontent-length:12\nexpires:0\ndestination:' \
-            b'/topic/xxxxxxxxxxxxxxxxxxxxxxxxxx' \
-            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id' \
-            b':ID\\cxxxxxx-35207-1543430467768-204' \
-            b'\\c363\\c-1\\c1\\c463860\npersistent:true\ntimestamp' \
-            b':1548945234005\n\n88.88.888.88' \
-            b'\x00\nMESSAGE\ncontent-length:11\nexpires:0\ndestination:' \
-            b'/topic/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' \
-            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id' \
-            b':ID\\cxxxxxx-35207-1543430467768-204'\
-            b'\\c362\\c-1\\c1\\c290793\npersistent:true\ntimestamp' \
-            b':1548945234005\n\n111.11.1.11' \
-            b'\x00\nMESSAGE\ncontent-length:14\nexpires:0\ndestination:' \
-            b'/topic/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' \
-            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id' \
-            b':ID\\cxxxxxx-35207-1543430467768-204' \
-            b'\\c362\\c-1\\c1\\c290794\npersistent:true\ntimestamp:' \
-            b'1548945234005\n\n222.222.22.222' \
-            b'\x00\nMESSAGE\ncontent-length:12\nexpires:0\ndestination:' \
-            b'/topic/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' \
-            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id' \
-            b':ID\\cxxxxxx-35207-1543430467768-204' \
-            b'\\c362\\c-1\\c1\\c290795\npersistent:true\ntimestamp:' \
+        data = (
+            b'MESSAGE\n'
+            b'content-length:14\nexpires:0\ndestination:/topic/'
+            b'xxxxxxxxxxxxxxxxxxxxxxxxxl'
+            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id'
+            b':ID\\cxxxxxx-35207-1543430467768-204'
+            b'\\c363\\c-1\\c1\\c463859\npersistent:true\ntimestamp'
+            b':1548945234003\n\n222.222.22.222'
+            b'\x00\nMESSAGE\ncontent-length:12\nexpires:0\ndestination:'
+            b'/topic/xxxxxxxxxxxxxxxxxxxxxxxxxx'
+            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id'
+            b':ID\\cxxxxxx-35207-1543430467768-204'
+            b'\\c363\\c-1\\c1\\c463860\npersistent:true\ntimestamp'
+            b':1548945234005\n\n88.88.888.88'
+            b'\x00\nMESSAGE\ncontent-length:11\nexpires:0\ndestination:'
+            b'/topic/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id'
+            b':ID\\cxxxxxx-35207-1543430467768-204'
+            b'\\c362\\c-1\\c1\\c290793\npersistent:true\ntimestamp'
+            b':1548945234005\n\n111.11.1.11'
+            b'\x00\nMESSAGE\ncontent-length:14\nexpires:0\ndestination:'
+            b'/topic/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id'
+            b':ID\\cxxxxxx-35207-1543430467768-204'
+            b'\\c362\\c-1\\c1\\c290794\npersistent:true\ntimestamp:'
+            b'1548945234005\n\n222.222.22.222'
+            b'\x00\nMESSAGE\ncontent-length:12\nexpires:0\ndestination:'
+            b'/topic/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id'
+            b':ID\\cxxxxxx-35207-1543430467768-204'
+            b'\\c362\\c-1\\c1\\c290795\npersistent:true\ntimestamp:'
             b'1548945234005\n\n88.88.888.88\x00\nMESS'
+        )
 
         stomp.data_received(data)
         await asyncio.sleep(0.001)
 
         self.assertEqual(message_handle_mock.call_count, 5)
-        self.assertEqual(b''.join(stomp._protocol.current_command), b'MESS')
+        self.assertEqual(bytes(stomp._protocol.current_command), b'MESS')
 
     @patch('aiostomp.aiostomp.StompReader._handle_message')
     @unittest_run_loop
@@ -331,7 +335,8 @@ class TestStompReader(AsyncTestCase):
             b'MESSAGE\n'
             b'content-length:14\nexpires:0\ndestination:/topic/'
             b'xxxxxxxxxxxxxxxxxxxxxxxxxl'
-            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id')
+            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id'
+        )
         await asyncio.sleep(0.001)
 
         stomp.data_received(
@@ -344,21 +349,24 @@ class TestStompReader(AsyncTestCase):
             b':ID\\cxxxxxx-35207-1543430467768-204'
             b'\\c363\\c-1\\c1\\c463860\npersistent:true\ntimestamp'
             b':1548945234005\n\n88.88.888.88'
-            b'\x00\nMESS')
+            b'\x00\nMESS'
+        )
         await asyncio.sleep(0.001)
 
         stomp.data_received(
             b'AGE\n'
             b'content-length:14\nexpires:0\ndestination:/topic/'
             b'xxxxxxxxxxxxxxxxxxxxxxxxxl'
-            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id')
+            b'\nsubscription:1\npriority:4\nActiveMQ.MQTT.QoS:1\nmessage-id'
+        )
         await asyncio.sleep(0.001)
 
         stomp.data_received(
             b':ID\\cxxxxxx-35207-1543430467768-204'
             b'\\c363\\c-1\\c1\\c463859\npersistent:true\ntimestamp'
             b':1548945234003\n\n222.222.22.222'
-            b'\x00')
+            b'\x00'
+        )
         await asyncio.sleep(0.001)
 
         self.assertEqual(message_handle_mock.call_count, 3)
@@ -377,7 +385,8 @@ class TestStompReader(AsyncTestCase):
             b'message-id:007\n'
             b'destination:/topic/test\n'
             b'\n'
-            b'blahh-line-a\n\nblahh-line-b\n\nblahh-line-c\x00')
+            b'blahh-line-a\n\nblahh-line-b\n\nblahh-line-c\x00'
+        )
 
         stomp.data_received(
             b'MESSAGE\n'
@@ -385,17 +394,15 @@ class TestStompReader(AsyncTestCase):
             b'message-id:007\n'
             b'destination:/topic/test\n'
             b'\n'
-            b'blahh-line-a\n\nblahh-line-b\n\nblahh-line-c\x00')
+            b'blahh-line-a\n\nblahh-line-b\n\nblahh-line-c\x00'
+        )
 
         await asyncio.sleep(0.001)
         self.assertEqual(message_handle_mock.call_count, 2)
 
     @unittest_run_loop
     async def test_can_handle_message(self):
-        frame = Frame('MESSAGE', {
-            'subscription': '123',
-            'message-id': '321'
-        }, 'blah')
+        frame = Frame('MESSAGE', {'subscription': '123', 'message-id': '321'}, 'blah')
 
         handler = CoroutineMock()
         subscription = Subscription('123', 1, 'auto', {}, handler)
@@ -410,10 +417,7 @@ class TestStompReader(AsyncTestCase):
 
     @unittest_run_loop
     async def test_can_handle_message_with_no_subscription(self):
-        frame = Frame('MESSAGE', {
-            'subscription': '123',
-            'message-id': '321'
-        }, 'blah')
+        frame = Frame('MESSAGE', {'subscription': '123', 'message-id': '321'}, 'blah')
 
         handler = CoroutineMock()
 
@@ -428,10 +432,7 @@ class TestStompReader(AsyncTestCase):
     @patch('aiostomp.aiostomp.StompReader.send_frame')
     @unittest_run_loop
     async def test_can_handle_message_can_ack(self, send_frame_mock):
-        frame = Frame('MESSAGE', {
-            'subscription': '123',
-            'message-id': '321'
-        }, 'blah')
+        frame = Frame('MESSAGE', {'subscription': '123', 'message-id': '321'}, 'blah')
 
         handler = CoroutineMock()
         handler.return_value = True
@@ -444,18 +445,14 @@ class TestStompReader(AsyncTestCase):
         await stomp._handle_message(frame)
 
         handler.assert_called_with(frame, frame.body)
-        send_frame_mock.assert_called_with('ACK', {
-            'subscription': '123',
-            'message-id': '321'
-        })
+        send_frame_mock.assert_called_with(
+            'ACK', {'subscription': '123', 'message-id': '321'}
+        )
 
     @patch('aiostomp.aiostomp.StompReader.send_frame')
     @unittest_run_loop
     async def test_can_handle_message_can_nack(self, send_frame_mock):
-        frame = Frame('MESSAGE', {
-            'subscription': '123',
-            'message-id': '321'
-        }, 'blah')
+        frame = Frame('MESSAGE', {'subscription': '123', 'message-id': '321'}, 'blah')
 
         handler = CoroutineMock()
         handler.return_value = False
@@ -468,10 +465,9 @@ class TestStompReader(AsyncTestCase):
         await stomp._handle_message(frame)
 
         handler.assert_called_with(frame, frame.body)
-        send_frame_mock.assert_called_with('NACK', {
-            'subscription': '123',
-            'message-id': '321'
-        })
+        send_frame_mock.assert_called_with(
+            'NACK', {'subscription': '123', 'message-id': '321'}
+        )
 
     @patch('aiostomp.aiostomp.StompReader._handle_error')
     @unittest_run_loop
@@ -482,7 +478,8 @@ class TestStompReader(AsyncTestCase):
             b'ERROR\n'
             b'message:Invalid error, blah, blah, blah\n'
             b'\n'
-            b'Detail Error: blah, blah, blah\x00')
+            b'Detail Error: blah, blah, blah\x00'
+        )
 
         await asyncio.sleep(0.001)
         error_handle_mock.assert_called_once()
@@ -490,9 +487,11 @@ class TestStompReader(AsyncTestCase):
     @patch('aiostomp.aiostomp.logger')
     @unittest_run_loop
     async def test_can_handle_error_frame(self, logger_mock):
-        frame = Frame('ERROR', {
-            'message': 'Invalid error, blah, blah, blah'
-        }, 'Detail Error: blah, blahh-line-a')
+        frame = Frame(
+            'ERROR',
+            {'message': 'Invalid error, blah, blah, blah'},
+            'Detail Error: blah, blahh-line-a',
+        )
 
         frame_handler = Mock()
         frame_handler._on_error = CoroutineMock()
@@ -502,13 +501,14 @@ class TestStompReader(AsyncTestCase):
         await stomp._handle_error(frame)
 
         frame_handler._on_error.assert_called_once()
-        self.assertTrue(
-            isinstance(frame_handler._on_error.call_args[0][0], StompError))
+        self.assertTrue(isinstance(frame_handler._on_error.call_args[0][0], StompError))
 
         logger_mock.error.assert_called_with(
-            'Received error: Invalid error, blah, blah, blah')
+            'Received error: Invalid error, blah, blah, blah'
+        )
         logger_mock.debug.assert_called_with(
-            'Error details: Detail Error: blah, blahh-line-a')
+            'Error details: Detail Error: blah, blahh-line-a'
+        )
 
     @patch('aiostomp.aiostomp.StompReader._handle_exception')
     @unittest_run_loop
@@ -519,22 +519,24 @@ class TestStompReader(AsyncTestCase):
             b'SOMETHING\n'
             b'message:Invalid error, blah, blah, blah\n'
             b'\n'
-            b'Detail Error: blah, blah, blah\x00')
+            b'Detail Error: blah, blah, blah\x00'
+        )
 
         await asyncio.sleep(0.001)
         exception_handle_mock.assert_called_once()
 
-    @patch('aiostomp.aiostomp.logger')
     @unittest_run_loop
-    async def test_can_handle_exception(self, logger_mock):
-        frame = Frame('SOMETHING', {
-            'message': 'Invalid error, blah, blah, blah'
-        }, 'Detail Error: blah, blahh-line-a')
+    async def test_can_handle_exception(self):
+        frame = Frame(
+            'SOMETHING',
+            {'message': 'Invalid error, blah, blah, blah'},
+            'Detail Error: blah, blahh-line-a',
+        )
 
         stomp = StompReader(None, self.loop)
-        await stomp._handle_exception(frame)
-
-        logger_mock.warn.assert_called_with('Unhandled frame: SOMETHING')
+        with self.assertLogs('aiostomp', level="WARNING") as cm:
+            await stomp._handle_exception(frame)
+            self.assertEqual(cm.output, ["WARNING:aiostomp:Unhandled frame: SOMETHING"])
 
     @unittest_run_loop
     async def test_can_process_empty_message(self):
@@ -555,7 +557,6 @@ class TestStompReader(AsyncTestCase):
 
 
 class TestAioStomp(AsyncTestCase):
-
     async def setUpAsync(self):
         self.stomp = AioStomp('127.0.0.1', 61613)
 
@@ -620,8 +621,7 @@ class TestAioStomp(AsyncTestCase):
 
         await self.stomp._reconnect()
 
-        logger_mock.error.assert_called_with(
-            'All connections attempts failed.')
+        logger_mock.error.assert_called_with('All connections attempts failed.')
         self.assertIsInstance(self.stomp._on_error.call_args[0][0], ExceededRetryCount)
         self.assertEqual(self.stomp._on_error.call_args[0][0].ref, self.stomp)
 
@@ -726,55 +726,62 @@ class TestAioStomp(AsyncTestCase):
         send_mock = Mock()
         self.stomp._protocol.send = send_mock
 
-        self.stomp.send('/topic/test', headers={
-            'my-header': 'my-value'
-        }, body='my body utf-8 ç')
+        self.stomp.send(
+            '/topic/test', headers={'my-header': 'my-value'}, body='my body utf-8 ç'
+        )
 
-        send_mock.assert_called_with({
-            'destination': '/topic/test',
-            'my-header': 'my-value',
-            'content-length': 16
-        }, b'my body utf-8 \xc3\xa7')
+        send_mock.assert_called_with(
+            {
+                'destination': '/topic/test',
+                'my-header': 'my-value',
+                'content-length': 16,
+            },
+            b'my body utf-8 \xc3\xa7',
+        )
 
     def test_can_send_message_with_body_binary(self):
         send_mock = Mock()
         self.stomp._protocol.send = send_mock
 
-        self.stomp.send('/topic/test', headers={
-            'my-header': 'my-value'
-        }, body=b'\xc3\xa7')
+        self.stomp.send(
+            '/topic/test', headers={'my-header': 'my-value'}, body=b'\xc3\xa7'
+        )
 
-        send_mock.assert_called_with({
-            'destination': '/topic/test',
-            'my-header': 'my-value',
-            'content-length': 2
-        }, b'\xc3\xa7')
+        send_mock.assert_called_with(
+            {
+                'destination': '/topic/test',
+                'my-header': 'my-value',
+                'content-length': 2,
+            },
+            b'\xc3\xa7',
+        )
 
-    def test_can_send_message_with_body_without_content_lenght(self):
+    def test_can_send_message_with_body_without_content_length(self):
         send_mock = Mock()
         self.stomp._protocol.send = send_mock
 
-        self.stomp.send('/topic/test', headers={
-            'my-header': 'my-value'
-        }, body='my body utf-8 ç', send_content_length=False)
+        self.stomp.send(
+            '/topic/test',
+            headers={'my-header': 'my-value'},
+            body='my body utf-8 ç',
+            send_content_length=False,
+        )
 
-        send_mock.assert_called_with({
-            'destination': '/topic/test',
-            'my-header': 'my-value'
-        }, b'my body utf-8 \xc3\xa7')
+        send_mock.assert_called_with(
+            {'destination': '/topic/test', 'my-header': 'my-value'},
+            b'my body utf-8 \xc3\xa7',
+        )
 
     def test_can_send_message_without_body(self):
         send_mock = Mock()
         self.stomp._protocol.send = send_mock
 
-        self.stomp.send('/topic/test', headers={
-            'my-header': 'my-value'
-        })
+        self.stomp.send('/topic/test', headers={'my-header': 'my-value'})
 
-        send_mock.assert_called_with({
-            'destination': '/topic/test',
-            'my-header': 'my-value',
-        }, '')
+        send_mock.assert_called_with(
+            {'destination': '/topic/test', 'my-header': 'my-value', 'content-length': 0},
+            b''
+        )
 
     def test_can_ack_a_frame(self):
         self.stomp._protocol.subscribe = Mock()
@@ -802,30 +809,30 @@ class TestAioStomp(AsyncTestCase):
 
         self.stomp._protocol.nack.assert_called_with(frame)
 
-    @patch('aiostomp.aiostomp.logger')
-    def test_cannot_ack_an_unsubscribed_frame(self, logger_mock):
+    def test_cannot_ack_an_unsubscribed_frame(self):
         self.stomp._protocol.ack = Mock()
         self.assertEqual(len(self.stomp._subscriptions), 0)
 
         frame = Frame('MESSAGE', {'subscription': '1'}, 'data')
 
-        self.stomp.ack(frame)
-        logger_mock.warn.assert_called_with('Subscription 1 not found.')
+        with self.assertLogs() as cm:
+            self.stomp.ack(frame)
+            self.assertIn('WARNING:aiostomp:Subscription 1 not found', cm.output)
         self.stomp._protocol.ack.assert_not_called()
 
-    @patch('aiostomp.aiostomp.logger')
-    def test_cannot_nack_an_unsubscribed_frame(self, logger_mock):
+    def test_cannot_nack_an_unsubscribed_frame(self):
         self.stomp._protocol.nack = Mock()
         self.assertEqual(len(self.stomp._subscriptions), 0)
 
         frame = Frame('MESSAGE', {'subscription': '1'}, 'data')
 
-        self.stomp.nack(frame)
-        logger_mock.warn.assert_called_with('Subscription 1 not found.')
+        with self.assertLogs() as cm:
+            self.stomp.nack(frame)
+            self.assertIn('WARNING:aiostomp:Subscription 1 not found', cm.output)
+
         self.stomp._protocol.nack.assert_not_called()
 
-    @patch('aiostomp.aiostomp.logger')
-    def test_cannot_ack_an_auto_ack_frame(self, logger_mock):
+    def test_cannot_ack_an_auto_ack_frame(self):
         self.stomp._protocol.subscribe = Mock()
         self.stomp._protocol.ack = Mock()
 
@@ -834,14 +841,16 @@ class TestAioStomp(AsyncTestCase):
 
         frame = Frame('MESSAGE', {'subscription': '1'}, 'data')
 
-        self.stomp.ack(frame)
+        with self.assertLogs() as cm:
+            self.stomp.ack(frame)
+            self.assertIn(
+                'WARNING:aiostomp:Auto ack/nack is enabled. Ignoring call.', cm.output
+            )
 
-        logger_mock.warn.assert_called_with('Auto ack/nack is enabled. Ignoring call.')
         self.stomp._protocol.ack.assert_not_called()
 
 
 class TestStompProtocol(AsyncTestCase):
-
     async def setUpAsync(self):
         self._handler = Mock()
         self._loop = Mock()
@@ -849,19 +858,19 @@ class TestStompProtocol(AsyncTestCase):
         self._tranport = Mock()
         self._protocol = Mock()
 
-        self._loop.create_connection.return_value = \
-            (self._tranport, self._protocol)
+        self._loop.create_connection.return_value = (self._tranport, self._protocol)
 
         self.protocol = StompProtocol(
-            self._handler, '127.0.0.1', 61613, loop=self._loop)
+            self._handler, '127.0.0.1', 61613, loop=self._loop
+        )
 
     @unittest_run_loop
     async def test_can_create_a_connection(self):
         await self.protocol.connect()
 
         self._loop.create_connection.assert_called_with(
-            self.protocol._factory, host='127.0.0.1', port=61613,
-            ssl=None)
+            self.protocol._factory, host='127.0.0.1', port=61613, ssl=None
+        )
 
     @unittest_run_loop
     async def test_can_close(self):
@@ -878,46 +887,42 @@ class TestStompProtocol(AsyncTestCase):
         await self.protocol.connect()
 
         self._loop.create_connection.assert_called_with(
-            self.protocol._factory, host='127.0.0.1', port=61613,
-            ssl=ssl_context)
+            self.protocol._factory, host='127.0.0.1', port=61613, ssl=ssl_context
+        )
 
     @unittest_run_loop
     async def test_can_subscribe(self):
         handler = Mock()
         subscription = Subscription(
-            '/queue/123',
-            1,
-            'client',
-            {'my-header': 'my-value'},
-            handler)
+            '/queue/123', 1, 'client', {'my-header': 'my-value'}, handler
+        )
 
         await self.protocol.connect()
         self.protocol.subscribe(subscription)
 
-        self._protocol.send_frame.assert_called_with('SUBSCRIBE', {
-            'id': 1,
-            'destination': '/queue/123',
-            'ack': 'client',
-            'my-header': 'my-value'
-        })
+        self._protocol.send_frame.assert_called_with(
+            'SUBSCRIBE',
+            {
+                'id': 1,
+                'destination': '/queue/123',
+                'ack': 'client',
+                'my-header': 'my-value',
+            },
+        )
 
     @unittest_run_loop
     async def test_can_unsubscribe(self):
         handler = Mock()
         subscription = Subscription(
-            '/queue/123',
-            1,
-            'client',
-            {'my-header': 'my-value'},
-            handler)
+            '/queue/123', 1, 'client', {'my-header': 'my-value'}, handler
+        )
 
         await self.protocol.connect()
         self.protocol.unsubscribe(subscription)
 
-        self._protocol.send_frame.assert_called_with('UNSUBSCRIBE', {
-            'id': 1,
-            'destination': '/queue/123',
-        })
+        self._protocol.send_frame.assert_called_with(
+            'UNSUBSCRIBE', {'id': 1, 'destination': '/queue/123'}
+        )
 
     @unittest_run_loop
     async def test_can_send(self):
@@ -926,4 +931,6 @@ class TestStompProtocol(AsyncTestCase):
         self.protocol.send({'content-length': 2}, '{}')
 
         self._protocol.send_frame.assert_called_with(
-            'SEND', {'content-length': 2}, '{}')
+            'SEND', {'content-length': 2}, '{}'
+        )
+

--- a/tests/test_recv_frame.py
+++ b/tests/test_recv_frame.py
@@ -1,6 +1,5 @@
 # -*- coding:utf-8 -*-
 from unittest import TestCase
-import six
 
 from aiostomp.protocol import StompProtocol
 
@@ -19,7 +18,7 @@ class TestRecvFrame(TestCase):
         )
 
     def test_on_decode_error_show_string(self):
-        data = MagicMock(spec=six.binary_type)
+        data = MagicMock(spec=bytes)
         data.decode.side_effect = UnicodeDecodeError(
             'hitchhiker',
             b"",


### PR DESCRIPTION
- Add type hints in most places
- Make all logging tests use assertLogging instead of a custom mock
- Use lazy log formatting
- Be strict about the types used when decoding (bytes vs int)